### PR TITLE
Fix get config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,6 @@ Support for retreiving full device informationn so you can see all available fun
 
 **V 0.5.1**
 - Fixed the testing suite and added on/off testing in binary.
+
+**V 0.5.2**
+- Get config was not returning all fields.  Query string was missing after migration to node-fetch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-sensibo",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Communication nodes to Sensibo cloud",
   "keywords": [
     "node-red",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-sensibo",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Communication nodes to Sensibo cloud",
   "keywords": [
     "node-red",

--- a/sensibo.js
+++ b/sensibo.js
@@ -16,9 +16,10 @@ module.exports = function (RED) {
       this.status({ fill: 'green', shape: 'ring', text: 'polling' })
 
       if (config.getconfig) {
-
         var apiURI = new URL(apiRoot + '/pods/' + config.pod)
         apiURI.searchParams.append('apiKey', node.api.sensibo_api)
+        apiURI.searchParams.append('fields', '*')
+        console.log(apiURI.href)
         var options = {
           method: 'GET',
           headers: { accept: 'application/json' } // Set to JSON
@@ -60,7 +61,6 @@ module.exports = function (RED) {
         fetch(apiURI, options)
           .then(res => res.json())
           .then(meas => {
-
             msg.temperature = meas.result[0].temperature
             msg.payload = meas.status
             msg.humidity = meas.result[0].humidity

--- a/test/config_in.js
+++ b/test/config_in.js
@@ -46,3 +46,32 @@ this.timerflow = [
 	}
 ]
 
+this.configflow = [
+	{
+		"id": "n1",
+		"type": "sensibo in",
+		"z": "c612c71c.4a4f98",
+		"sensiboAPI": "fcfae818.98aca8",
+		"name": "sensibo in",
+		"pod": config.pod,
+		"getconfig": true,
+		"polltime": "0",
+		"x": 360,
+		"y": 140,
+		"wires": [
+			[
+				"nh"
+			]
+		]
+	},
+	{
+		"id": "fcfae818.98aca8",
+		"type": "sensibo-config",
+		"z": "",
+		"senAPI": config.api
+	},
+	{ 
+		id: 'nh', 
+		type: 'helper' 
+	}
+]

--- a/test/sensibo_in_spec.js
+++ b/test/sensibo_in_spec.js
@@ -62,4 +62,16 @@ describe('sensibo Node', function () {
       })
     })
   })
+  it('should get full configuration', function (done) {
+    helper.load(sensibo, config.configflow, function () {
+      var n1 = helper.getNode('n1')
+      var nh = helper.getNode('nh')
+      nh.on('input', function (msg) {
+        console.log('Testing:' + JSON.stringify(msg))
+        msg.should.have.property('status', 'success')
+        done()
+      })
+      n1.receive({ payload: 'getMeasurement' })
+    })
+  })
 })


### PR DESCRIPTION
The query string to get all fields was not carried over to node-fetch so the get config option only returned basic node data.  Updated now to get all available fields as per previous versions.